### PR TITLE
Added check using cppcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,19 @@
 SUBDIRS=docs lib tests buildutils
 EXTRA_DIST=RELEASE_VERSION
 
+CPPCHECK_CMD=	cppcheck
+CPPCHECK_OPT=	--quiet \
+				--error-exitcode=1 \
+				--inline-suppr \
+				-j 4 \
+				--std=c++03 \
+				--xml \
+				--enable=warning,style,information,missingInclude
+CPPCHECK_IGN=
+
+cppcheck:
+	$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS)
+
 #
 # VIM modelines
 #

--- a/buildutils/travis_builder.sh
+++ b/buildutils/travis_builder.sh
@@ -321,10 +321,27 @@ else
 	#
 	# Using RHSCL because centos has older ruby
 	#
-	run_cmd yum install -y -qq centos-release-scl
-	run_cmd yum install -y -qq rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake
+	run_cmd ${INSTALLER_BIN} install -y -qq centos-release-scl
+	run_cmd ${INSTALLER_BIN} install -y -qq rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake
 	source /opt/rh/rh-ruby23/enable
 	run_cmd ${GEM_BIN} install rubocop package_cloud
+fi
+
+#
+# For cppcheck
+#
+if [ ${IS_CENTOS} -eq 1 ]; then
+	#
+	# For CentOS, it need to allow EPEL(with setting disable)
+	#
+	run_cmd ${INSTALLER_BIN} install -y -qq epel-release
+	run_cmd yum-config-manager --disable epel
+	run_cmd ${INSTALLER_BIN} --enablerepo=epel install -y -qq cppcheck
+else
+	#
+	# Fedora, Ubuntu...
+	#
+	run_cmd ${INSTALLER_BIN} install -y -qq cppcheck
 fi
 
 #
@@ -337,6 +354,7 @@ SRCTOP="/tmp/${TMPSRCTOP}"
 run_cmd cd ${SRCTOP}
 run_cmd ./autogen.sh
 run_cmd ./configure --prefix=/usr ${CONFIGUREOPT}
+run_cmd make cppcheck
 run_cmd make
 run_cmd make check
 

--- a/lib/k2htpmdtorlibs.cc
+++ b/lib/k2htpmdtorlibs.cc
@@ -86,7 +86,7 @@ bool MdtorTpLib::Load(const char* path, const char* pconfig)
 	}
 
 	// check symbol
-	const char*	pError = dlerror();		// call because dlerror result is set NULL.
+	const char*	pError;				// call because dlerror result is set NULL.
 	bool		result = true;
 	if(NULL == (fp_k2h_trans = reinterpret_cast<Tfp_k2h_trans>(dlsym(hDynLib, "k2h_trans"))) && NULL != (pError = dlerror())){
 		ERR_K2HPRN("Failed to load symbol(k2h_trans), error = %s", pError ? pError : "unknown");

--- a/lib/k2htpmdtorsolo.cc
+++ b/lib/k2htpmdtorsolo.cc
@@ -325,6 +325,8 @@ bool K2HtpMdtorSolo::LoadConfigrationYaml(const char* config, MDTORMODE& mode, m
 		// open configuration file
 		if(NULL == (fp = fopen(config, "r"))){
 			ERR_K2HPRN("Could not open configuration file(%s). errno = %d", config, errno);
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress resourceLeak
 			return false;
 		}
 		// set file to parser

--- a/tests/k2htpmdtordmy.cc
+++ b/tests/k2htpmdtordmy.cc
@@ -79,6 +79,8 @@ bool k2h_trans(k2h_h handle, PBCOM pBinCom)
 	// open log file(default stdout)
 	FILE*	fp = stdout;
 	if(GetLogFile().empty() || NULL == (fp = fopen(GetLogFile().c_str(), "a+"))){
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress resourceLeak
 		fp = stdout;
 	}
 


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Added cppcheck
We made use of cppcheck.  
cppcheck will automatically run on TravisCI.  
If you want to run it manually, please use `make cppcheck`.  

In this PR, we corrected errors etc. detected by cppcheck.

#### NOTE
cppcheck depends on the OS of the build environment, and different versions are used for each.  
This PR is trying to eliminate this difference.
