### PR TITLE
Enabled external customization of configure.ac and fixed for building

### DIFF
--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -146,6 +146,11 @@ elif [ "X${CI_OSTYPE}" = "Xcentos:8" -o "X${CI_OSTYPE}" = "Xcentos:centos8" ]; t
 	PKG_EXT="rpm"
 	IS_OS_CENTOS=1
 
+	#
+	# Change mirrorlist
+	#
+	sed -i -e 's|^mirrorlist|#mirrorlist|g' -e 's|^#baseurl=http://mirror|baseurl=http://vault|g' /etc/yum.repos.d/CentOS-*repo
+
 	# [NOTE]
 	# For CentOS8, installing libyaml-devel from PowerTools( PwoerTools -> powertools at 2020/12 )
 	#

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,7 @@
 #
 
 SUBDIRS=docs lib tests buildutils
-EXTRA_DIST=RELEASE_VERSION
+EXTRA_DIST=RELEASE_VERSION @CONFIGURECUSTOM@
 
 CPPCHECK_CMD=	cppcheck
 CPPCHECK_OPT=	--quiet \
@@ -31,7 +31,10 @@ cppcheck:
 	$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS)
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/configure.ac
+++ b/configure.ac
@@ -78,15 +78,39 @@ AC_CHECK_FUNCS([memset strcasecmp strdup])
 AC_CONFIG_MACRO_DIR([m4])
 
 #
-# For OSS products
-# In the OSS version, you need to change the following.
+# Load customizable variables
 #
-AC_SUBST([GIT_DOMAIN], github.com)
-AC_SUBST([GIT_ORG], "yahoojapan")
-AC_SUBST([GIT_REPO], "k2htp_mdtor")
-AC_SUBST([CURRENTREV], "`$(pwd)/buildutils/make_commit_hash.sh -o yahoojapan -r k2htp_mdtor -short`")
-AC_SUBST([DEV_EMAIL], "`echo ${DEBEMAIL:-antpickax-support@mail.yahoo.co.jp}`")
-AC_SUBST([DEV_NAME], "`echo ${DEBFULLNAME:-K2HASH_DEVELOPER}`")
+AC_CHECK_FILE([configure.custom],
+	[
+		configure_custom_file="configure.custom"
+		custom_git_domain="$(grep '^\s*GIT_DOMAIN\s*=' configure.custom | sed -e 's|^\s*GIT_DOMAIN\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_org="$(grep '^\s*GIT_ORG\s*=' configure.custom | sed -e 's|^\s*GIT_ORG\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_repo="$(grep '^\s*GIT_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_endpoint="$(grep '^\s*GIT_EP_V3_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_EP_V3_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_email="$(grep '^\s*DEV_EMAIL\s*=' configure.custom | sed -e 's|^\s*DEV_EMAIL\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_name="$(grep '^\s*DEB_NAME\s*=' configure.custom | sed -e 's|^\s*DEB_NAME\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+	],
+	[
+		configure_custom_file=""
+		custom_git_domain="github.com"
+		custom_git_org="yahoojapan"
+		custom_git_repo="k2htp_mdtor"
+		custom_git_endpoint="https://api.github.com/repos/"
+		custom_dev_email="antpickax-support@mail.yahoo.co.jp"
+		custom_dev_name="K2HASH_DEVELOPER"
+	]
+)
+
+#
+# Symbols for buildutils
+#
+AC_SUBST([CONFIGURECUSTOM], "${configure_custom_file}")
+AC_SUBST([GIT_DOMAIN], "${custom_git_domain}")
+AC_SUBST([GIT_ORG], "${custom_git_org}")
+AC_SUBST([GIT_REPO], "${custom_git_repo}")
+AC_SUBST([CURRENTREV], "$($(pwd)/buildutils/make_commit_hash.sh -o "${custom_git_org}" -r "${custom_git_repo}" -ep "${custom_git_endpoint}" -short)")
+AC_SUBST([DEV_EMAIL], "$(echo ${DEBEMAIL:-"${custom_dev_email}"})")
+AC_SUBST([DEV_NAME], "$(echo ${DEBFULLNAME:-"${custom_dev_name}"})")
 #
 AC_SUBST([RPMCHANGELOG], "`$(pwd)/buildutils/make_rpm_changelog.sh $(pwd)/ChangeLog`")
 AC_SUBST([SHORTDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/k2htpmdtor.3 -short`")
@@ -157,7 +181,10 @@ AC_CONFIG_FILES([Makefile
 AC_OUTPUT
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -16,15 +16,13 @@
 #
 
 ##############################################################
-
-##############################################################
 ## library path & programs path
 ##
 CTPTESTSDIR=`dirname $0`
 if [ "X${SRCTOP}" = "X" ]; then
 	SRCTOP=`cd ${CTPTESTSDIR}/..; pwd`
 else
-	CTPTESTSDIR=`cd -P ${SRTOP}/tests; pwd`
+	CTPTESTSDIR=`cd -P ${SRCTOP}/tests; pwd`
 fi
 CTPLIBDIR=`cd -P ${SRCTOP}/lib; pwd`
 cd ${CTPTESTSDIR}
@@ -54,7 +52,6 @@ elif [ -f ${CTPLIBDIR}/libk2htpmdtor.so.1 ]; then
 else
 	echo "ERROR: there is no libk2htpmdtor.so.* binary"
 	echo "RESULT --> FAILED"
-
 	exit 1
 fi
 
@@ -96,7 +93,6 @@ ${CTPTESTBIN} ${DTORLIBSO} ${CTPTESTSDIR}/test.ini
 if [ $? -ne 0 ]; then
 	echo "ERROR: test program returned false."
 	echo "RESULT --> FAILED"
-
 	exit 1
 fi
 echo "RESULT --> SUCCEED"
@@ -111,7 +107,6 @@ SED_LOG_FILE2=`sed 's/\[0x[0-9a-f]*\] //' ${TEST_LOG_FILE2} 2> /dev/null`
 if [ "X${SED_LOG_FILE1}" = "X" -o "X${SED_LOG_FILE2}" = "X" -o "X${SED_LOG_FILE1}" != "X${SED_LOG_FILE2}" ]; then
 	echo "ERROR: test result is false."
 	echo "RESULT --> FAILED"
-
 	exit 1
 fi
 echo "RESULT --> SUCCEED"
@@ -143,7 +138,6 @@ ${CTPTESTBIN} ${DTORLIBSO} ${CTPTESTSDIR}/test.yaml
 if [ $? -ne 0 ]; then
 	echo "ERROR: test program returned false."
 	echo "RESULT --> FAILED"
-
 	exit 1
 fi
 echo "RESULT --> SUCCEED"
@@ -158,7 +152,6 @@ SED_LOG_FILE2=`sed 's/\[0x[0-9a-f]*\] //' ${TEST_LOG_FILE2} 2> /dev/null`
 if [ "X${SED_LOG_FILE1}" = "X" -o "X${SED_LOG_FILE2}" = "X" -o "X${SED_LOG_FILE1}" != "X${SED_LOG_FILE2}" ]; then
 	echo "ERROR: test result is false."
 	echo "RESULT --> FAILED"
-
 	exit 1
 fi
 echo "RESULT --> SUCCEED"
@@ -190,7 +183,6 @@ ${CTPTESTBIN} ${DTORLIBSO} ${CTPTESTSDIR}/test.json
 if [ $? -ne 0 ]; then
 	echo "ERROR: test program returned false."
 	echo "RESULT --> FAILED"
-
 	exit 1
 fi
 echo "RESULT --> SUCCEED"
@@ -205,7 +197,6 @@ SED_LOG_FILE2=`sed 's/\[0x[0-9a-f]*\] //' ${TEST_LOG_FILE2} 2> /dev/null`
 if [ "X${SED_LOG_FILE1}" = "X" -o "X${SED_LOG_FILE2}" = "X" -o "X${SED_LOG_FILE1}" != "X${SED_LOG_FILE2}" ]; then
 	echo "ERROR: test result is false."
 	echo "RESULT --> FAILED"
-
 	exit 1
 fi
 echo "RESULT --> SUCCEED"
@@ -231,7 +222,6 @@ JSON_STRING_DATA=`grep 'JSON_STRING=' ${CTPTESTSDIR}/test_json_string.data 2>/de
 if [ $? -ne 0 ]; then
 	echo "ERROR: failed initializing for JSON string data."
 	echo "RESULT --> FAILED"
-
 	exit 1
 fi
 echo "RESULT --> SUCCEED"
@@ -245,7 +235,6 @@ ${CTPTESTBIN} ${DTORLIBSO} "${JSON_STRING_DATA}"
 if [ $? -ne 0 ]; then
 	echo "ERROR: test program returned false."
 	echo "RESULT --> FAILED"
-
 	exit 1
 fi
 echo "RESULT --> SUCCEED"
@@ -260,7 +249,6 @@ SED_LOG_FILE2=`sed 's/\[0x[0-9a-f]*\] //' ${TEST_LOG_FILE2} 2> /dev/null`
 if [ "X${SED_LOG_FILE1}" = "X" -o "X${SED_LOG_FILE2}" = "X" -o "X${SED_LOG_FILE1}" != "X${SED_LOG_FILE2}" ]; then
 	echo "ERROR: test result is false."
 	echo "RESULT --> FAILED"
-
 	exit 1
 fi
 echo "RESULT --> SUCCEED"
@@ -288,8 +276,6 @@ echo "====== Finish all =========================================="
 echo ""
 echo "RESULT --> SUCCEED"
 echo ""
-
-
 
 exit 0
 


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
- Enabled to customize variables in configure.ac  
If the configure.custom file exists, it will be loaded.  
(currently unused but added to increase availability)
- Fixed an error output by cppcheck 2.7(etc)
- Fixed CentOS 8 build failing.  
It was caused by changing the mirror, so I fixed it.

