### PR TITLE
Fixed .gitignore to exclude APKBUILD.templ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,20 +38,6 @@
 *.dll
 
 #
-# Precompiled Headers
-#
-*.gch
-*.pch
-
-#
-# Compiled Dynamic libraries
-#
-*.so
-*.so.*
-*.dylib
-*.dll
-
-#
 # Fortran module files
 #
 *.mod
@@ -100,6 +86,7 @@ stamp-h1
 #
 Makefile.in
 Makefile
+buildutils/APKBUILD.templ
 
 #
 # archive files and backups


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
Fixed leaking `buildutils/APKBUILD.templ` in `.gitignore`.
And it was also removed unnecessary lines.