### PR TITLE
Changed support OS (fedora and ubuntu) and updated tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,15 +63,14 @@ jobs:
         container:
           - ubuntu:22.04
           - ubuntu:20.04
-          - ubuntu:18.04
           - debian:bookworm
           - debian:bullseye
           - debian:buster
           - rockylinux:9
           - rockylinux:8
           - centos:centos7
+          - fedora:38
           - fedora:37
-          - fedora:36
           - alpine:3.18
 
     container:

--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -122,20 +122,6 @@ elif [ "${CI_OSTYPE}" = "ubuntu:20.04" ] || [ "${CI_OSTYPE}" = "ubuntu:focal" ];
 	PKG_EXT="deb"
 	IS_OS_UBUNTU=1
 
-elif [ "${CI_OSTYPE}" = "ubuntu:18.04" ] || [ "${CI_OSTYPE}" = "ubuntu:bionic" ]; then
-	DIST_TAG="ubuntu/bionic"
-	INSTALL_PKG_LIST="git autoconf autotools-dev gcc g++ make gdb dh-make fakeroot dpkg-dev devscripts libtool pkg-config ruby-dev rubygems procps rubygems-integration libyaml-dev chmpx-dev gnutls-dev"
-	INSTALLER_BIN="apt-get"
-	UPDATE_CMD="update"
-	UPDATE_CMD_ARG=""
-	INSTALL_CMD="install"
-	INSTALL_CMD_ARG=""
-	INSTALL_AUTO_ARG="-y"
-	INSTALL_QUIET_ARG="-qq"
-	PKG_OUTPUT_DIR="debian_build"
-	PKG_EXT="deb"
-	IS_OS_UBUNTU=1
-
 elif [ "${CI_OSTYPE}" = "debian:12" ] || [ "${CI_OSTYPE}" = "debian:bookworm" ]; then
 	DIST_TAG="debian/bookworm"
 	INSTALL_PKG_LIST="git autoconf autotools-dev gcc g++ make gdb dh-make fakeroot dpkg-dev devscripts libtool pkg-config ruby-dev rubygems procps rubygems-integration libyaml-dev chmpx-dev gnutls-dev"
@@ -242,8 +228,8 @@ elif [ "${CI_OSTYPE}" = "centos:7" ] || [ "${CI_OSTYPE}" = "centos:centos7" ]; t
 	PKG_EXT="rpm"
 	IS_OS_CENTOS=1
 
-elif [ "${CI_OSTYPE}" = "fedora:37" ]; then
-	DIST_TAG="fedora/37"
+elif [ "${CI_OSTYPE}" = "fedora:38" ]; then
+	DIST_TAG="fedora/38"
 	INSTALL_PKG_LIST="git autoconf automake gcc gcc-c++ gdb make libtool pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps libyaml-devel chmpx-devel nss-devel"
 	INSTALLER_BIN="dnf"
 	UPDATE_CMD="update"
@@ -256,8 +242,8 @@ elif [ "${CI_OSTYPE}" = "fedora:37" ]; then
 	PKG_EXT="rpm"
 	IS_OS_FEDORA=1
 
-elif [ "${CI_OSTYPE}" = "fedora:36" ]; then
-	DIST_TAG="fedora/36"
+elif [ "${CI_OSTYPE}" = "fedora:37" ]; then
+	DIST_TAG="fedora/37"
 	INSTALL_PKG_LIST="git autoconf automake gcc gcc-c++ gdb make libtool pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps libyaml-devel chmpx-devel nss-devel"
 	INSTALLER_BIN="dnf"
 	UPDATE_CMD="update"

--- a/buildutils/control.in
+++ b/buildutils/control.in
@@ -2,7 +2,7 @@ Source: @PACKAGE_NAME@
 Section: libs
 Priority: optional
 Maintainer: @DEV_NAME@ <@DEV_EMAIL@>
-Build-Depends: @DEBHELPER_DEP@, k2hash-dev (>= 1.0.89), libfullock-dev (>= 1.0.53), chmpx-dev (>= 1.0.102), libyaml-dev, gnutls-dev
+Build-Depends: @DEBHELPER_DEP@, k2hash-dev (>= 1.0.90), libfullock-dev (>= 1.0.55), chmpx-dev (>= 1.0.103), libyaml-dev, gnutls-dev
 Depends: ${misc:Depends}
 Standards-Version: 3.9.8
 Homepage: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
@@ -12,6 +12,6 @@ Vcs-Browser: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
 Package: @PACKAGE_NAME@
 Section: libs
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, k2hash (>= 1.0.89), libfullock (>= 1.0.53), chmpx (>= 1.0.102)
+Depends: ${shlibs:Depends}, ${misc:Depends}, k2hash (>= 1.0.90), libfullock (>= 1.0.55), chmpx (>= 1.0.103)
 Description: @SHORTDESC@
 @DEBLONGDESC@

--- a/buildutils/k2htpmdtor.spec.in
+++ b/buildutils/k2htpmdtor.spec.in
@@ -52,8 +52,8 @@ License: @PKGLICENSE@
 @RPMPKG_GROUP@
 URL: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@
 Source0: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@/archive/%{gittag}/%{name}-%{version}.tar.gz
-Requires: libfullock%{?_isa} >= 1.0.53, k2hash%{?_isa} >= 1.0.89, chmpx%{?_isa} >= 1.0.102
-BuildRequires: git-core gcc-c++ make libtool libfullock-devel >= 1.0.53, k2hash-devel >= 1.0.89, chmpx-devel >= 1.0.102, libyaml-devel, nss-devel
+Requires: libfullock%{?_isa} >= 1.0.55, k2hash%{?_isa} >= 1.0.90, chmpx%{?_isa} >= 1.0.103
+BuildRequires: git-core gcc-c++ make libtool libfullock-devel >= 1.0.55, k2hash-devel >= 1.0.90, chmpx-devel >= 1.0.103, libyaml-devel, nss-devel
 
 %description
 @LONGDESC@

--- a/configure.ac
+++ b/configure.ac
@@ -156,9 +156,9 @@ AC_ARG_ENABLE(check-depend-libs,
 	esac]
 )
 AS_IF([test ${check_depend_libs} = 1], [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no)])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.53], [], [AC_MSG_ERROR(not found libfullock package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.89], [], [AC_MSG_ERROR(not found k2hash package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.102], [], [AC_MSG_ERROR(not found chmpx package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.55], [], [AC_MSG_ERROR(not found libfullock package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.90], [], [AC_MSG_ERROR(not found k2hash package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.103], [], [AC_MSG_ERROR(not found chmpx package)])])
 
 #
 # CFLAGS/CXXFLAGS


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
- Supported OS has been changed.  
Does not support fedora 36  
Added support for fedora 38  
Does not support Ubuntu 18.04  

- Fixed `build_helper.sh`  
The minimum Ruby version required for the `package_cloud` command has been changed to 2.6, and `build_helper.sh` has been modified accordingly.

- Updated package dependencies.