### PR TITLE
Updated dependent package versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -146,9 +146,9 @@ AS_IF([test "$PKG_CONFIG" = "no"], [AC_MSG_ERROR(You have to install pkg-config 
 #
 # Version list for Libraries
 #
-AC_SUBST([LIB_MINVER_LIBCHMPX], "1.0.108")
-AC_SUBST([LIB_MINVER_LIBK2HASH], "1.0.98")
-AC_SUBST([LIB_MINVER_LIBFULLOCK], "1.0.62")
+AC_SUBST([LIB_MINVER_LIBCHMPX], "1.0.109")
+AC_SUBST([LIB_MINVER_LIBK2HASH], "1.0.99")
+AC_SUBST([LIB_MINVER_LIBFULLOCK], "1.0.63")
 
 #
 # Checking Libraries
@@ -163,9 +163,9 @@ AC_ARG_ENABLE(check-depend-libs,
 	esac]
 )
 AS_IF([test ${check_depend_libs} = 1], [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no)])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.62], [], [AC_MSG_ERROR(not found libfullock package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.98], [], [AC_MSG_ERROR(not found k2hash package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.108], [], [AC_MSG_ERROR(not found chmpx package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.63], [], [AC_MSG_ERROR(not found libfullock package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.99], [], [AC_MSG_ERROR(not found k2hash package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.109], [], [AC_MSG_ERROR(not found chmpx package)])])
 
 #
 # CFLAGS/CXXFLAGS


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
The versions of dependent packages (`libfullock`, `k2hash`, `chmpx`) have been updated.